### PR TITLE
Switch to Math.idiv

### DIFF
--- a/driver.ts
+++ b/driver.ts
@@ -3,6 +3,8 @@
  */
 //% weight=100 color=#0fbc11 icon=""
 namespace PCA9685 {
+    Math.idiv = Math.idiv || (a, b)=>a/b;
+
     let _DEBUG: boolean = false
     const debug = (msg: string) => {
         if (_DEBUG === true) {
@@ -221,7 +223,7 @@ namespace PCA9685 {
         setOffsetsFromFreq(startFreq: number, stopFreq: number, midFreq: number = -1): void {
             this.minOffset = startFreq // calcFreqOffset(startFreq)
             this.maxOffset = stopFreq // calcFreqOffset(stopFreq)
-            this.midOffset = midFreq > -1 ? midFreq : ((stopFreq - startFreq) / 2) + startFreq
+            this.midOffset = midFreq > -1 ? midFreq : Math.idiv((stopFreq - startFreq), 2) + startFreq
         }
 
         config(): string[] {
@@ -267,7 +269,7 @@ namespace PCA9685 {
     export const chips: ChipConfig[] = []
 
     function calcFreqPrescaler(freq: number): number {
-        return (25000000 / (freq * chipResolution)) - 1;
+        return Math.idiv(25000000, (freq * chipResolution)) - 1;
     }
 
     function stripHexPrefix(str: string): string {
@@ -302,7 +304,7 @@ namespace PCA9685 {
     }
 
     function calcFreqOffset(freq: number, offset: number) {
-        return ((offset * 1000) / (1000 / freq) * chipResolution) / 10000
+        return (Math.idiv((offset * 1000), Math.idiv(1000, freq)) * chipResolution) / 10000
     }
 
     /**
@@ -409,7 +411,7 @@ namespace PCA9685 {
         debug(`Spread ${spread}`)
         servo.position = speed
         speed = Math.abs(speed)
-        const calcOffset: number = ((speed * spread) / 100)
+        const calcOffset: number = Math.idiv((speed * spread), 100)
         debug(`Offset ${calcOffset}`)
         debug(`min ${offsetStart}`)
         debug(`mid ${offsetMid}`)
@@ -435,7 +437,7 @@ namespace PCA9685 {
         maxTimeCs = Math.max(0, maxTimeCs)
         debug(`setServoLimits(${servoNum}, ${minTimeCs}, ${maxTimeCs}, ${chipAddress})`)
         const servo: ServoConfig = chip.servos[servoNum - 1]
-        midTimeCs = midTimeCs > -1 ? midTimeCs : ((maxTimeCs - minTimeCs) / 2) + minTimeCs
+        midTimeCs = midTimeCs > -1 ? midTimeCs : Math.idiv((maxTimeCs - minTimeCs), 2) + minTimeCs
         debug(`midTimeCs ${midTimeCs}`)
         return servo.setOffsetsFromFreq(minTimeCs, maxTimeCs, midTimeCs)
     }

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pca9685",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Generic PCA9685 driver for the BBC micro:bit",
     "dependencies": {
         "core": "*",


### PR DESCRIPTION
Introduces a monkey patch for Math.idiv that wraps / if Math.idiv isn't present.  This allows same code to work on either v0 or v1 platforms.  Switches all / operations out to Math.idiv, retains same math as changing math would result in v0 platforms breaking.