### PR TITLE
Update pxt.json and readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 
 # micro:bit PCA9685 driver
 
-This is an extremely generic PCA9685 driver for the BBC micro:bit and Microsoft MakeCode.
+This is an extremely generic PCA9685 driver for the BBC micro:bit and Microsoft MakeCode Editor.
 
-Support for LED, Servo, Continuous Rotation Servo and direct manipulation of the PCA9685 is supported.
+Supported LED, Servo, Continuous Rotation Servo and direct manipulation of the PCA9685.
+
+![pca9685_01](https://user-images.githubusercontent.com/44191076/47269928-d9c24b80-d596-11e8-8627-65a4f2349518.JPG)
 
 ## Adding to Project
 
-From within [MakeCode](https://makecode.microbit.org/) select the "Advanced" section.  Click on "Add Package" in the "Search or enter project URL..." section enter "jdarling/pxt-pca9685"
+From within [MakeCode](https://makecode.microbit.org/) select the "Advanced" section. Click on "+ Extensions" in the "Search or enter project URL..." section enter "jdarling/pxt-pca9685" or simply "PCA9685".
+
+![002](https://user-images.githubusercontent.com/44191076/47691442-09272700-dc2d-11e8-98bc-c6a800acb15f.jpg)
+![003](https://user-images.githubusercontent.com/44191076/47691443-09272700-dc2d-11e8-8faf-97b047e6282c.jpg)
+
+![001](https://user-images.githubusercontent.com/44191076/47691444-09272700-dc2d-11e8-802b-d0bbf76c9468.jpg)
 
 ## Constants
 
@@ -131,6 +138,8 @@ Changes the chip frequency to the value passed in between 40Hz and 1000Hz then p
 Maintains the existing chip frequency setup and performs a chip init, see init(chipAddress, frequency) for more details.
 
 ## Example Usage
+
+![microbit-screenshot](https://user-images.githubusercontent.com/44191076/47691636-d5003600-dc2d-11e8-90f9-38d755a81ee2.png)
 
 ```
 let controller = 0

--- a/pxt.json
+++ b/pxt.json
@@ -2,6 +2,7 @@
     "name": "pca9685",
     "version": "0.0.4",
     "description": "Generic PCA9685 driver for the BBC micro:bit",
+    "license": "MIT",
     "dependencies": {
         "core": "*"
     },

--- a/pxt.json
+++ b/pxt.json
@@ -1,14 +1,13 @@
 {
     "name": "pca9685",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Generic PCA9685 driver for the BBC micro:bit",
     "dependencies": {
-        "core": "*",
-        "radio": "*"
+        "core": "*"
     },
     "files": [
         "driver.ts",
-        "readme.md"
+        "README.md"
     ],
     "testFiles": [
       "tests.ts"


### PR DESCRIPTION
HI, thanks for the fix. And I've made some minor changes.

In pxt.json the radio dependency is not needed. It prevents user to add Bluetooth-related packages. (I've changed this in a forked repository of your older 0.0.1 version and it works.)

And I update the readme file a bit. I think renaming the file would let the content appear in MakeCode site. It sure would be more user-friendly.

https://makecode.microbit.org/pkg/jdarling/pxt-pca9685#setcrservoposition

Alan